### PR TITLE
Add delete endpoint to Prompt API

### DIFF
--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -2,6 +2,7 @@
 imports:
   commons: ./commons.yml
   pagination: ./utils/pagination.yml
+  scim: ./scim.yml
 service:
   auth: true
   base-path: /api/public/v2
@@ -56,6 +57,25 @@ service:
       path: /prompts
       request: CreatePromptRequest
       response: Prompt
+
+    delete:
+      docs: Delete a prompt or specific versions
+      method: DELETE
+      path: /prompts/{promptName}
+      path-parameters:
+        promptName:
+          type: string
+          docs: The name of the prompt
+      request:
+        name: DeletePromptRequest
+        query-parameters:
+          label:
+            type: optional<string>
+            docs: Optional label of the prompt to delete
+          version:
+            type: optional<integer>
+            docs: Optional version of the prompt to delete
+      response: scim.EmptyResponse
 
 types:
   PromptMetaListResponse:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2763,6 +2763,58 @@ paths:
           content:
             application/json:
               schema: {}
+    delete:
+      description: Delete a prompt or specific versions
+      operationId: prompts_delete
+      tags:
+        - Prompts
+      parameters:
+        - name: promptName
+          in: path
+          description: The name of the prompt
+          required: true
+          schema:
+            type: string
+        - name: label
+          in: query
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: version
+          in: query
+          required: false
+          schema:
+            type: integer
+            nullable: true
+      responses:
+        '204':
+          description: ''
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
       security:
         - BasicAuth: []
   /api/public/v2/prompts:

--- a/web/src/features/prompts/server/actions/deletePrompt.ts
+++ b/web/src/features/prompts/server/actions/deletePrompt.ts
@@ -1,0 +1,47 @@
+import { InvalidRequestError, LangfuseNotFoundError } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import { PromptService, redis, logger } from "@langfuse/shared/src/server";
+
+export type DeletePromptParams = {
+  promptName: string;
+  projectId: string;
+  version?: number | null;
+  label?: string;
+};
+
+export const deletePrompt = async (params: DeletePromptParams) => {
+  const { promptName, projectId, version, label } = params;
+
+  if (version && label) {
+    throw new InvalidRequestError("Cannot specify both version and label");
+  }
+
+  const where = {
+    projectId,
+    name: promptName,
+    ...(version ? { version } : {}),
+    ...(label ? { labels: { has: label } } : {}),
+  };
+
+  const prompts = await prisma.prompt.findMany({ where });
+
+  if (prompts.length === 0) {
+    throw new LangfuseNotFoundError("Prompt not found");
+  }
+
+  const promptService = new PromptService(prisma, redis);
+
+  try {
+    await promptService.lockCache({ projectId, promptName });
+    await promptService.invalidateCache({ projectId, promptName });
+
+    await prisma.prompt.deleteMany({
+      where: { projectId, id: { in: prompts.map((p) => p.id) } },
+    });
+  } catch (err) {
+    logger.error(err, "Failed to delete prompt");
+    throw err;
+  } finally {
+    await promptService.unlockCache({ projectId, promptName });
+  }
+};

--- a/web/src/tests/async/prompts.v2.servertest.ts
+++ b/web/src/tests/async/prompts.v2.servertest.ts
@@ -1,0 +1,96 @@
+/** @jest-environment node */
+
+import { prisma } from "@langfuse/shared/src/db";
+import { makeAPICall, pruneDatabase } from "@/src/__tests__/test-utils";
+import { v4 as uuidv4 } from "uuid";
+
+const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+const baseURI = "/api/public/v2/prompts";
+
+describe("DELETE /api/public/v2/prompts/{promptName}", () => {
+  beforeEach(pruneDatabase);
+
+  it("deletes all versions of a prompt", async () => {
+    const name = "deletePrompt" + uuidv4();
+    await prisma.prompt.createMany({
+      data: [
+        {
+          id: uuidv4(),
+          name,
+          prompt: "p1",
+          labels: ["production"],
+          version: 1,
+          projectId,
+          createdBy: "user",
+          config: {},
+          type: "TEXT",
+        },
+        {
+          id: uuidv4(),
+          name,
+          prompt: "p2",
+          labels: [],
+          version: 2,
+          projectId,
+          createdBy: "user",
+          config: {},
+          type: "TEXT",
+        },
+      ],
+    });
+
+    const res = await makeAPICall("DELETE", `${baseURI}/${encodeURIComponent(name)}`);
+    expect(res.status).toBe(204);
+
+    const remaining = await prisma.prompt.findMany({ where: { projectId, name } });
+    expect(remaining.length).toBe(0);
+  });
+
+  it("deletes by label and version", async () => {
+    const name = "deletePromptFiltered" + uuidv4();
+    await prisma.prompt.createMany({
+      data: [
+        {
+          id: uuidv4(),
+          name,
+          prompt: "p1",
+          labels: ["production"],
+          version: 1,
+          projectId,
+          createdBy: "user",
+          config: {},
+          type: "TEXT",
+        },
+        {
+          id: uuidv4(),
+          name,
+          prompt: "p2",
+          labels: ["dev"],
+          version: 2,
+          projectId,
+          createdBy: "user",
+          config: {},
+          type: "TEXT",
+        },
+      ],
+    });
+
+    const res1 = await makeAPICall(
+      "DELETE",
+      `${baseURI}/${encodeURIComponent(name)}?version=1`,
+    );
+    expect(res1.status).toBe(204);
+
+    let remaining = await prisma.prompt.findMany({ where: { projectId, name } });
+    expect(remaining.length).toBe(1);
+
+    const res2 = await makeAPICall(
+      "DELETE",
+      `${baseURI}/${encodeURIComponent(name)}?label=dev`,
+    );
+    expect(res2.status).toBe(204);
+
+    remaining = await prisma.prompt.findMany({ where: { projectId, name } });
+    expect(remaining.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement backend action `deletePrompt`
- expose new DELETE /api/public/v2/prompts/{promptName} handler
- document DELETE endpoint in API specs
- extend public OpenAPI specification
- add tests for deleting prompts

## Testing
- `pnpm run lint` *(fails: fetch failed - no internet)*
- `pnpm test` *(fails: fetch failed - no internet)*

------
https://chatgpt.com/codex/tasks/task_b_686a5f05252c8320892ae19555dcf02c