### PR TITLE
feat(web): auto render external input images

### DIFF
--- a/web/src/components/trace/IOPreview.tsx
+++ b/web/src/components/trace/IOPreview.tsx
@@ -163,6 +163,7 @@ export const IOPreview: React.FC<{
                   className="ph-no-capture"
                   content={input}
                   media={media?.filter((m) => m.field === "input") ?? []}
+                  isDefaultImageVisible={true}
                 />
               ) : null}
               {!(hideIfNull && !output) && !hideOutput ? (

--- a/web/src/components/ui/MarkdownJsonView.tsx
+++ b/web/src/components/ui/MarkdownJsonView.tsx
@@ -82,6 +82,16 @@ const isSupportedMarkdownFormat = (
 
 // MarkdownJsonView will render markdown if `isMarkdownEnabled` (global context) is true and the content is valid markdown
 // otherwise, if content is valid markdown will render JSON with switch to enable markdown globally
+interface MarkdownJsonViewProps {
+  content?: unknown;
+  title?: string;
+  className?: string;
+  customCodeHeaderClassName?: string;
+  audio?: OpenAIOutputAudioType;
+  media?: MediaReturnType[];
+  isDefaultImageVisible?: boolean;
+}
+
 export function MarkdownJsonView({
   content,
   title,
@@ -89,14 +99,8 @@ export function MarkdownJsonView({
   customCodeHeaderClassName,
   audio,
   media,
-}: {
-  content?: unknown;
-  title?: string;
-  className?: string;
-  customCodeHeaderClassName?: string;
-  audio?: OpenAIOutputAudioType;
-  media?: MediaReturnType[];
-}) {
+  isDefaultImageVisible,
+}: MarkdownJsonViewProps) {
   const stringOrValidatedMarkdown = useMemo(
     () => StringOrMarkdownSchema.safeParse(content),
     [content],
@@ -121,6 +125,7 @@ export function MarkdownJsonView({
           customCodeHeaderClassName={customCodeHeaderClassName}
           audio={audio}
           media={media}
+          isDefaultImageVisible={isDefaultImageVisible}
         />
       ) : (
         <JSONView

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -106,17 +106,21 @@ const isImageNode = (node?: ReactMarkdownNode): boolean =>
       "tagName" in child && child.tagName === "img",
   );
 
+interface MarkdownRendererProps {
+  markdown: string;
+  theme?: string;
+  className?: string;
+  customCodeHeaderClassName?: string;
+  isDefaultImageVisible?: boolean;
+}
+
 function MarkdownRenderer({
   markdown,
   theme,
   className,
   customCodeHeaderClassName,
-}: {
-  markdown: string;
-  theme?: string;
-  className?: string;
-  customCodeHeaderClassName?: string;
-}) {
+  isDefaultImageVisible,
+}: MarkdownRendererProps) {
   // Try to parse markdown content
 
   try {
@@ -224,7 +228,13 @@ function MarkdownRenderer({
             );
           },
           img({ src, alt }) {
-            return src ? <ResizableImage src={src} alt={alt} /> : null;
+            return src ? (
+              <ResizableImage
+                src={src}
+                alt={alt}
+                isDefaultVisible={isDefaultImageVisible}
+              />
+            ) : null;
           },
           hr() {
             return <hr className="my-4" />;
@@ -290,19 +300,23 @@ const parseOpenAIContentParts = (
     .join("\n");
 };
 
+interface MarkdownViewerProps {
+  markdown: string | z.infer<typeof OpenAIContentSchema>;
+  title?: string;
+  customCodeHeaderClassName?: string;
+  audio?: OpenAIOutputAudioType;
+  media?: MediaReturnType[];
+  isDefaultImageVisible?: boolean;
+}
+
 export function MarkdownView({
   markdown,
   title,
   customCodeHeaderClassName,
   audio,
   media,
-}: {
-  markdown: string | z.infer<typeof OpenAIContentSchema>;
-  title?: string;
-  customCodeHeaderClassName?: string;
-  audio?: OpenAIOutputAudioType;
-  media?: MediaReturnType[];
-}) {
+  isDefaultImageVisible,
+}: MarkdownViewerProps) {
   const capture = usePostHogClientCapture();
   const { resolvedTheme: theme } = useTheme();
   const { setIsMarkdownEnabled } = useMarkdownContext();
@@ -348,6 +362,7 @@ export function MarkdownView({
             markdown={markdown}
             theme={theme}
             customCodeHeaderClassName={customCodeHeaderClassName}
+            isDefaultImageVisible={isDefaultImageVisible}
           />
         ) : (
           // content parts (multi-modal)
@@ -358,6 +373,7 @@ export function MarkdownView({
                 markdown={content.text}
                 theme={theme}
                 customCodeHeaderClassName={customCodeHeaderClassName}
+                isDefaultImageVisible={isDefaultImageVisible}
               />
             ) : isOpenAIImageContentPart(content) ? (
               OpenAIUrlImageUrl.safeParse(content.image_url.url).success ? (
@@ -392,6 +408,7 @@ export function MarkdownView({
               markdown={audio.transcript ? "[Audio] \n" + audio.transcript : ""}
               theme={theme}
               customCodeHeaderClassName={customCodeHeaderClassName}
+              isDefaultImageVisible={isDefaultImageVisible}
             />
             <LangfuseMediaView
               mediaReferenceString={audio.data.referenceString}


### PR DESCRIPTION
## Summary
- allow images to automatically render in the input field only
- plumb `isDefaultImageVisible` prop through Markdown viewer components

## Testing
- `pnpm run lint` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_b_686a5fa5dce083208cf0fbacccadfbc3