### PR TITLE
Fix trace link encoding

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -287,7 +287,7 @@ export const SessionPage: React.FC<{
             </div>
             <div className="-mt-1 p-1 opacity-50 transition-opacity group-hover:opacity-100">
               <Link
-                href={`/project/${projectId}/traces/${trace.id}`}
+                href={`/project/${projectId}/traces/${encodeURIComponent(trace.id)}`}
                 className="text-xs hover:underline"
               >
                 Trace: {trace.name} ({trace.id})&nbsp;↗


### PR DESCRIPTION
## Summary
- encode trace links on session page

## Testing
- `pnpm run lint` *(fails: Request was cancelled due to no network)*

------
https://chatgpt.com/codex/tasks/task_b_686e5f5c0d0c8320ad569ddc94b62669