### PR TITLE
Update prompt filtering by folder depth

### DIFF
--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -128,6 +128,7 @@ export function PromptTable() {
   };
 
   const currentFolderPath = queryParams.folder || "";
+  const folderDepth = (currentFolderPath ? currentFolderPath.split("/").length : 0) + 1;
 
   const prompts = api.prompts.all.useQuery(
     {
@@ -138,6 +139,7 @@ export function PromptTable() {
       orderBy: orderByState,
       pathPrefix: currentFolderPath,
       searchQuery: searchQuery || undefined,
+      folderDepth,
     },
     {
       enabled: Boolean(projectId),


### PR DESCRIPTION
## Summary
- extend `PromptFilterOptions` with optional `folderDepth`
- filter SQL queries by depth via `generatePromptQuery`
- pass folder depth from `PromptTable`

## Testing
- `pnpm run lint` *(fails: Request was cancelled due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_b_686e9e04bcb88320bbf4d9a736f3855a